### PR TITLE
Rewrite logic of ucwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Uppercase the first character of each word in a string.
 ```php
 \MathiasReker\PhpMbFunctions\Mbstring::ucwords(
     string $string,
+    string $separators = " \t\r\n\f\v",
     string $encoding = 'UTF-8'
 ): string
 ```

--- a/src/Mbstring.php
+++ b/src/Mbstring.php
@@ -65,24 +65,12 @@ final class Mbstring implements MbstringInterface
         $string = strtr($string, $map);
     }
 
-    public static function ucwords(string $string, string $encoding = 'UTF-8'): string
+    public static function ucwords(string $string, string $separators = " \t\r\n\f\v", string $encoding = 'UTF-8'): string
     {
-        $result = '';
-        $previousCharacter = ' ';
+        $escaped = preg_quote($separators, '/');
+        $pattern = '/(^|[' . $escaped . '])(\p{L})/u';
 
-        $length = mb_strlen($string, $encoding);
-        for ($i = 0; $i < $length; ++$i) {
-            $currentCharacter = mb_substr($string, $i, 1, $encoding);
-
-            if (' ' === $previousCharacter) {
-                $currentCharacter = mb_strtoupper($currentCharacter, $encoding);
-            }
-
-            $result .= $currentCharacter;
-            $previousCharacter = $currentCharacter;
-        }
-
-        return $result;
+        return preg_replace_callback($pattern, fn ($matches): string => $matches[1] . mb_strtoupper($matches[2], $encoding), $string) ?? "";
     }
 
     public static function ucfirst(string $string, string $encoding = 'UTF-8'): string

--- a/tests/Unit/MbUcwordsTest.php
+++ b/tests/Unit/MbUcwordsTest.php
@@ -25,6 +25,7 @@ final class MbUcwordsTest extends TestCase
     public function testUppercaseAllWords(): void
     {
         $this->assertEquals('The Quick Brown Fox', Mbstring::ucwords('the quick brown fox'));
+        $this->assertEquals('The QUiCK BrOwn FoX', Mbstring::ucwords('the qUiCK brOwn foX'));
     }
 
     public function testHandlesNonASCIICharacters(): void

--- a/tests/Unit/MbUcwordsTest.php
+++ b/tests/Unit/MbUcwordsTest.php
@@ -26,6 +26,7 @@ final class MbUcwordsTest extends TestCase
     {
         $this->assertEquals('The Quick Brown Fox', Mbstring::ucwords('the quick brown fox'));
         $this->assertEquals('The QUiCK BrOwn FoX', Mbstring::ucwords('the qUiCK brOwn foX'));
+        $this->assertEquals('The-Quick-Brown-Fox', Mbstring::ucwords('the-quick-brown-fox', '-'));
     }
 
     public function testHandlesNonASCIICharacters(): void


### PR DESCRIPTION
Support `$separators = " \t\r\n\f\v"` as `ucwords()`